### PR TITLE
update deps

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -46,7 +46,7 @@ modules@0.6.3
 modules-runtime@0.6.4
 mongo@1.1.9
 mongo-id@1.0.5
-nathantreid:css-modules@2.0.2
+nathantreid:css-modules@2.1.0
 nathantreid:css-modules-import-path-helpers@0.1.3
 npm-mongo@1.4.44
 observe-sequence@1.0.12

--- a/client/components/style.scss
+++ b/client/components/style.scss
@@ -1,4 +1,4 @@
-@import "~react-toolbox/lib/base";
+@import "~react-toolbox/lib/globals";
 @import "~react-toolbox/lib/app_bar/config";
 @import "~react-toolbox/lib/button/config";
 

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ToolboxApp from 'react-toolbox/lib/app';
 import Button from 'react-toolbox/lib/button';
 import Header from './components/header';
 import style from './style';
 
 Meteor.startup(function () {
     ReactDOM.render((
-      <ToolboxApp>
+      <div>
           <Header />
           <section className={style.content}>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero sed arcu vehicula ultricies a non tortor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ut gravida lorem. Ut turpis felis, pulvinar a semper sed, adipiscing id dolor. Pellentesque auctor nisi id magna consequat sagittis. Curabitur dapibus enim sit amet elit pharetra tincidunt feugiat nisl imperdiet. Ut convallis libero in urna ultrices accumsan. Donec sed odio eros. Donec viverra mi quis quam pulvinar at malesuada arcu rhoncus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In rutrum accumsan ultricies. Mauris vitae nisi at sem facilisis semper ac in est.
           </section>
           <Button label='test' />
-      </ToolboxApp>
+      </div>
     ), document.getElementById('app'));
 });

--- a/client/toolbox-theme.scss
+++ b/client/toolbox-theme.scss
@@ -1,2 +1,2 @@
-$color-primary: $palette-blue-500 !default;
-$color-primary-dark: $palette-blue-700 !default;
+$color-primary: $palette-red-500 !default;
+$color-primary-dark: $palette-green-300 !default;

--- a/client/toolbox-theme.scss
+++ b/client/toolbox-theme.scss
@@ -1,2 +1,2 @@
-$color-primary: $palette-red-500 !default;
-$color-primary-dark: $palette-green-300 !default;
+$color-primary: $palette-blue-500 !default;
+$color-primary-dark: $palette-blue-700 !default;

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
     "start": "meteor run"
   },
   "dependencies": {
-    "meteor-node-stubs": "~0.2.0",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7",
-    "react-toolbox": "^0.14.2"
+    "meteor-node-stubs": "~0.2.3",
+    "normalize.css": "^4.1.1",
+    "react": "^15.1.0",
+    "react-addons-css-transition-group": "^15.1.0",
+    "react-dom": "^15.1.0",
+    "react-toolbox": "^1.0.1"
   },
   "cssModules": {
     "extensions": [
@@ -16,11 +18,13 @@
     ],
     "globalVariables": [
       "node_modules/react-toolbox/lib/_colors.scss",
-      { "theme-building": true },
+      {
+        "theme-building": true
+      },
       "client/toolbox-theme.scss"
-    ],
-    "outputJsFilePath": {
-      ".*node_modules/react-toolbox/.*": "{dirname}/{basename}"
-    }
+    ]
+  },
+  "devDependencies": {
+    "node-sass": "^3.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "react-dom": "^15.1.0",
     "react-toolbox": "^1.0.1"
   },
+  "devDependencies": {
+    "node-sass": "^3.4.2"
+  },
   "cssModules": {
     "extensions": [
       "scss"
@@ -23,8 +26,5 @@
       },
       "client/toolbox-theme.scss"
     ]
-  },
-  "devDependencies": {
-    "node-sass": "^3.4.2"
   }
 }


### PR DESCRIPTION
since nearly all deps have new major versions it would be nice to use them in this example. I confirmed that this config works (at least for me). Two things to look out for:

in `package.json` inside `cssModules` configuration  the part

```
"outputJsFilePath": {
     ".*node_modules/react-toolbox/.*": "{dirname}/{basename}"
}
```

is not needed anymore after `react-toolbox@1.0.0` version.

Also if you use `npm install` instead of `meteor npm install` remember to run `meteor npm rebuild node-sass` to connect binary to meteor's nodejs.
